### PR TITLE
Revise title-generation function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,15 @@ use std::fmt::Write;
 
 #[derive(PartialEq, Eq)]
 pub struct Roff {
-    title: String,
+    title_string: Vec<&'static str>,
     section: i8,
     content: Vec<Section>,
 }
 
 impl Roff {
-    pub fn new(title: &str, section: i8) -> Self {
+    pub fn new(title_string: Vec<&'static str>, section: i8) -> Self {
         Roff {
-            title: title.into(),
+            title_string: title_string,
             section,
             content: Vec::new(),
         }
@@ -32,13 +32,16 @@ impl Roff {
 impl Troffable for Roff {
     fn render(&self) -> String {
         let mut res = String::new();
+        res.push_str(".TH ");
+        for element in &self.title_string {
+            if element.len() > 1 {
+                res.push_str(format!("\"{}\" ", element).as_str());
+            } else {
+                res.push_str(format!("{} ", element).as_str());
+            }
+        }
 
-        writeln!(
-            &mut res,
-            ".TH {} {}",
-            self.title.to_uppercase(),
-            self.section
-        ).unwrap();
+        writeln!(&mut res, "\n").unwrap();
         for section in &self.content {
             writeln!(&mut res, "{}", escape(&section.render())).unwrap();
         }

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -1,6 +1,7 @@
-extern crate roff;
 extern crate duct;
-#[macro_use] extern crate pretty_assertions;
+extern crate roff;
+#[macro_use]
+extern crate pretty_assertions;
 
 fn roff_to_ascii(input: &str) -> String {
     duct::cmd("troff", &["-a", "-mman"])
@@ -14,34 +15,63 @@ fn roff_to_ascii(input: &str) -> String {
 fn demo() {
     use roff::*;
 
-    let page = Roff::new("corrupt", 1)
-        .section("name", &["corrupt - modify files by randomly changing bits"])
-        .section("SYNOPSIS", &[
-            bold("corrupt"), " ".into(),
-            "[".into(), bold("-n"), " ".into(), italic("BITS"), "]".into(),
+    let page = Roff::new(
+        vec!["CORRUPT", "1", "January 2019", "3.8.0", "User Commands"],
+        1,
+    )
+    .section(
+        "name",
+        &["corrupt - modify files by randomly changing bits"],
+    )
+    .section(
+        "SYNOPSIS",
+        &[
+            bold("corrupt"),
             " ".into(),
-            "[".into(), bold("--bits"), " ".into(), italic("BITS"), "]".into(),
+            "[".into(),
+            bold("-n"),
             " ".into(),
-            italic("file"), "...".into(),
-        ])
-        .section("description", &[
+            italic("BITS"),
+            "]".into(),
+            " ".into(),
+            "[".into(),
+            bold("--bits"),
+            " ".into(),
+            italic("BITS"),
+            "]".into(),
+            " ".into(),
+            italic("file"),
+            "...".into(),
+        ],
+    )
+    .section(
+        "description",
+        &[
             bold("corrupt"),
             " modifies files by toggling a randomly chosen bit.".into(),
-        ])
-        .section("options", &[
-            list(
-                &[bold("-n"), ", ".into(), bold("--bits"), "=".into(), italic("BITS")],
-                &[
-                    "Set the number of bits to modify. ",
-                    "Default is one bit.",
-                ]
-            ),
-        ])
-        ;
+        ],
+    )
+    .section(
+        "options",
+        &[list(
+            &[
+                bold("-n"),
+                ", ".into(),
+                bold("--bits"),
+                "=".into(),
+                italic("BITS"),
+            ],
+            &["Set the number of bits to modify. ", "Default is one bit."],
+        )],
+    );
 
     // use std::io::Write;
     // let mut f = ::std::fs::File::create("./tests/demo.generated.troff").unwrap();
     // f.write_all(&page.render().as_bytes());
 
-    assert_eq!(roff_to_ascii(include_str!("./demo.troff")), roff_to_ascii(&page.render()));
+    println!("{}", &page.render());
+    assert_eq!(
+        roff_to_ascii(include_str!("./demo.troff")),
+        roff_to_ascii(&page.render())
+    );
 }

--- a/tests/demo.troff
+++ b/tests/demo.troff
@@ -1,4 +1,4 @@
-.TH CORRUPT 1
+.TH CORRUPT 1 "January 2019" "3.8.0" "User Commands"
 .SH NAME
 corrupt \- modify files by randomly changing bits
 .SH SYNOPSIS


### PR DESCRIPTION
This PR revises the title-generation function to accept a Vec of Strings.  This allows it to accept other arguments that are passed to .TH (such as the date and version).  As disscussed in #6, this would be useful to any users of roff-rs that want to configure the date or version for a man page (including `man`).

It also removes the capitalization, in part because not all of these arguments are capitalized and in part because that degree of semantic formatting (titles need to be capitalized) seems more appropriate for a higher level crate like `man`.